### PR TITLE
Backward compatibility for URLs with format

### DIFF
--- a/src/RestRoute.php
+++ b/src/RestRoute.php
@@ -99,6 +99,12 @@ class RestRoute implements IRouter {
     }
     $presenterName = ucfirst(array_pop($frags));
 
+    // allow to use URLs like project.tld/presenter.format
+    $formats = join('|', array_keys($this->formats));
+    if (Strings::match($presenterName, "/.+\.({$formats})$/")) {
+        list($presenterName, $format) = explode('.', $presenterName);
+    }
+
     // Associations.
     $assoc = array();
     if (count($frags) > 0 && count($frags) % 2 === 0) {


### PR DESCRIPTION
This update allows to use URLs like project.tld/presenter.format. Because of I wrote API based on newPOPE/Nette-RestRoute with URLs like /event.json and it stop works after update.

Thanks
