### PR TITLE
Allow to set non-even number of associations

### DIFF
--- a/src/RestRoute.php
+++ b/src/RestRoute.php
@@ -243,10 +243,6 @@ class RestRoute extends Object implements IRouter {
     if (isset($parameters['associations']) && Validators::is($parameters['associations'], 'array')) {
       $associations = & $parameters['associations'];
 
-      if (count($associations) % 2 !== 0) {
-        throw new InvalidStateException("Number of associations is not even");
-      }
-
       foreach ($associations as $key => $value) {
         $urlStack[] = $key;
         $urlStack[] = $value;


### PR DESCRIPTION
Check for even number of assosiation is IMO wrong, because when I want to have odd number of associations (e.g. `/api/v1/model/1/result/1`, where `/api/v1` is base, `model/1` is 1 association `model=>1`, presenter is `Result` and `id` is `1`), it fails.
