### PR TITLE
Added support for URL module versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ $router[] = new RestRoute('Api');
 
 // With module and xml as a default format.
 $router[] = new RestRoute('Api', 'xml');
+
+// With URL module versioning
+$router[] = (new RestRoute())
+    ->useURLModuleVersioning(
+        '/v[0-9\.]+/',     // Regex for URL version
+        [                  // URL fragment to module mapping
+          NULL => 'V1',    // Default version module is V1
+          'v1' => 'V1',    // /v1 to module V1
+          'v2' => 'V2'     // /v2 to module V2
+        ]
+    );
 ```
 
 
@@ -262,6 +273,33 @@ associations = array(
 )
 data = ""
 query = array(0)
+```
+
+---
+### URL versioning:
+RestRoute provides you with option to version your API in URL. Each version is represented by separate module in your application.
+
+First, you define regexp which is used to detect if the version parameter is present in URL. It must be in the begging of the path.
+Then, you define version to module mapping. `NULL` key stands for default module, if version parameter doesn't get detected.
+
+```php
+$router[] = (new RestRoute('Api')) // Optional module
+    ->useURLModuleVersioning(
+        '/v[0-9\.]+/',     // Regex for URL version
+        [                  // URL fragment to module mapping
+          NULL => 'V1',    // Default version module is V1
+          'v1' => 'V1',    // /v1 to module V1
+          'v2' => 'V2'     // /v2 to module V2
+        ]
+    );
+```
+
+RestRoute will now map your requests to presenters like this (URL -> Presenter):
+
+```
+/api/foo        ->  Api:V1:Foo
+/api/v1/foo     ->  Api:V1:Foo
+/api/v2/foo     ->  Api:V2:Foo
 ```
 
 ---

--- a/tests/RestRouteTest.php
+++ b/tests/RestRouteTest.php
@@ -126,6 +126,33 @@ class RestRouteTest extends \PHPUnit_Framework_TestCase {
     }
   }
 
+  /**
+   * @dataProvider getVersions
+   */
+  public function testModuleVersioning($module, $path, $expectedPresenterName, $expectedUrl) {
+    $route = new RestRoute($module);
+    $route->useURLModuleVersioning(
+      '/v[0-9\.]+/', 
+      [
+        NULL => 'V1',
+        'v1' => 'V1',
+        'v2' => 'V2'
+      ]
+  );
+
+    $url = new UrlScript();
+    $url->setPath($path);
+    $request = new Request($url, NULL, NULL, NULL, NULL, NULL, 'GET');
+
+    $appRequest = $route->match($request);
+
+    $this->assertEquals($expectedPresenterName, $appRequest->getPresenterName());
+
+    $refUrl = new Url('http://localhost');
+    $url = $route->constructUrl($appRequest, $refUrl);
+    $this->assertEquals($expectedUrl, $url);
+  }
+
   public function getActions() {
     return [
       ['POST', '/foo', 'create'],
@@ -137,4 +164,15 @@ class RestRouteTest extends \PHPUnit_Framework_TestCase {
       ['OPTIONS', '/foo', 'options'],
     ];
   }
+
+  public function getVersions() {
+    return [
+      [NULL, '/foo', 'V1:Foo', 'http://localhost/v1/foo'],
+      [NULL, '/v1/foo', 'V1:Foo', 'http://localhost/v1/foo'],
+      [NULL, '/v2/foo', 'V2:Foo', 'http://localhost/v2/foo'],
+      ['Api', '/api/foo', 'Api:V1:Foo', 'http://localhost/api/v1/foo'],
+      ['Api', '/api/v1/foo', 'Api:V1:Foo', 'http://localhost/api/v1/foo'],
+    ];
+  }
+
 }


### PR DESCRIPTION
ref #16

Now you can use URL versioning with support of modules.
see [Readme - URL versioning](https://github.com/klimesf/Nette-RestRoute#url-versioning)