### PR TITLE
enable using Nette utils v2.5 when possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": "^7.0",
     "nette/application": "^2.4",
     "nette/http": "^2.4",
-    "nette/utils": "^2.4"
+    "nette/utils": "^2.4 || ^2.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.2",


### PR DESCRIPTION
When trying to use the package together with Nette 2.4, you run into dependency conflict, because nette/component-model requires at least nette/utils ^2.5.