### PR TITLE
apt-get update must be in one RUN with apt-get install

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,8 +1,7 @@
 FROM php:7.2
 MAINTAINER adam.stipak@gmail.com
 
-RUN apt-get update
-RUN apt-get install -y zlib1g-dev
+RUN apt-get update && apt-get install -y zlib1g-dev
 RUN docker-php-ext-install zip mbstring
 RUN curl -sS https://getcomposer.org/installer |php -- --install-dir=/usr/local/bin --filename=composer
 


### PR DESCRIPTION
apt-get update must be in one RUN with apt-get install to prevent caching issues